### PR TITLE
Fix python-dotenv import error on Streamlit Cloud

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 spotipy==2.23.0
-python-dotenv==1.0.0
+python-dotenv==1.1.1
 tqdm==4.66.0
 pandas==2.2.0
 streamlit==1.42.0


### PR DESCRIPTION
## Summary
- bump python-dotenv to 1.1.1 in requirements to ensure compatibility with Python 3.13 environments

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e14561300083309ce2378a3872f146