### PR TITLE
Unpin dependency versions in requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-spotipy==2.23.0
-python-dotenv==1.1.1
-tqdm==4.66.0
-pandas==2.2.0
-streamlit==1.42.0
-plotly==5.19.0
+spotipy
+python-dotenv
+tqdm
+pandas
+streamlit
+plotly


### PR DESCRIPTION
## Summary
- remove pinned versions from requirements so the newest releases are installed

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e21b9d354883308e0a61e3fa8699a9